### PR TITLE
Update actions/download-artifact to v4, specify build/ destination folder

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -73,6 +73,7 @@ jobs:
               uses: actions/download-artifact@v4
               with:
                   name: valtimo-backend-build
+                  path: build/
           -   name: 'Login to github packages'
               uses: docker/login-action@v1
               with:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -67,9 +67,10 @@ jobs:
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Download build artifact
-              uses: actions/download-artifact@v2
+              uses: actions/download-artifact@v4
               with:
                   name: valtimo-backend-build
+                  path: build/
 
             - name: Build and push Docker image
               uses: docker/build-push-action@v2


### PR DESCRIPTION
Currently the build pipeline is broken because `actions/download-artifact@v2` is deprecated.

When updating to v4, we need to specify that the artifact is downloaded to `build/`, else it will unzip the artifact contents in the working directory, which breaks the build.