### PR TITLE
updated GitPod base image location

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ritensebv/gitpod-java17-postgres:11-7-23-4
+image: ritense/gitpod:java17-postgres
 vscode:
   extensions:
     - richardwillis.vscode-gradle


### PR DESCRIPTION
For what it's worth, updated GitPod base image location to Docker Ritense user so the org. can be removed